### PR TITLE
Update setup.cfg - fix https://github.com/karpierz/libpcap/issues/2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ where = src
 
 [options.package_data]
 libpcap = libpcap.cfg
-libpcap._platform = */*/*.dll, */*/*.so, */*/*.dylib, */*/.keep
+libpcap._platform = */*/*/*.dll, */*/*/*.so, */*/*.dylib, */*/*/.keep
 
 [options.extras_require]
 doc =


### PR DESCRIPTION
This fixed https://github.com/karpierz/libpcap/issues/2 for me

I double-checked that all provided `.dll`, `.so` and `.keep` files are installed at least on python 3.7.3 (debian 10) and 3.8.2 (ubuntu 20).

But please also check with your setup, because I am not sure why it might have worked for you before.