### PR TITLE
Support for Mac OSX x64

### DIFF
--- a/src/libpcap/_platform/_osx/__init__.py
+++ b/src/libpcap/_platform/_osx/__init__.py
@@ -13,8 +13,10 @@ is_32bit = (sys.maxsize <= 2**32)
 arch     = "x86" if is_32bit else "x64"
 arch_dir = os.path.join(this_dir, arch)
 
-raise NotImplementedError("This OS is not supported yet!")
+if is_32bit:
+    raise NotImplementedError("This OS is not supported in 32 bit!")
 
+found = False
 try:
     from ...__config__ import config
     LIBPCAP = config.get("LIBPCAP", None)
@@ -22,12 +24,16 @@ try:
     if LIBPCAP is None or LIBPCAP in ("", "None"):
         raise ImportError()
 except ImportError:
-    LIBPCAP = "tcpdump"  # !!! temporary? !!!
+    # On Mac, use ports or homebrew to install libpcap if it's not present!
+    LIBPCAP = find_library("pcap")
+    if not LIBPCAP:
+        raise OSError("Cannot find libpcap.dylib library. Install from homebrew or other package manager!") from None
+    found = True
 
 if os.path.isabs(LIBPCAP):
     DLL_PATH = LIBPCAP
 else:
-    DLL_PATH = os.path.join(arch_dir, LIBPCAP, "libpcap-1.0.dylib")
+    DLL_PATH = os.path.join(arch_dir, LIBPCAP, "libpcap.dylib")
 
 from ctypes  import CDLL as DLL
 from _ctypes import dlclose
@@ -55,4 +61,69 @@ class timeval(ct.Structure):
     _fields_ = [
     ("tv_sec",  time_t),       # seconds
     ("tv_usec", suseconds_t),  # microseconds
+]
+
+# Taken from the file libpcap's "socket.h"
+
+# Some minor differences between sockets on various platforms.
+# We include whatever sockets are needed for Internet-protocol
+# socket access.
+
+# In UN*X, a socket handle is a file descriptor, and therefore
+# a signed integer.
+SOCKET = ct.c_int
+
+# In UN*X, the error return if socket() fails is -1.
+INVALID_SOCKET = SOCKET(-1).value
+
+class sockaddr(ct.Structure):
+    _fields_ = [
+    ("sa_family", ct.c_short),
+    ("__pad1",    ct.c_ushort),
+    ("ipv4_addr", ct.c_byte * 4),
+    ("ipv6_addr", ct.c_byte * 16),
+    ("__pad2",    ct.c_ulong),
+]
+
+# POSIX.1g specifies this type name for the `sa_family' member.
+sa_family_t = ct.c_ushort
+
+# Type to represent a port.
+in_port_t = ct.c_uint16
+
+# IPv4 AF_INET sockets:
+
+class in_addr(ct.Structure):
+    _fields_ = [
+    ("s_addr", ct.c_uint32),
+]
+
+class sockaddr_in(ct.Structure):
+    _fields_ = [
+    ("sin_family", sa_family_t),  # e.g. AF_INET, AF_INET6
+    ("sin_port",   in_port_t),    # Port number.
+    ("sin_addr",   in_addr),      # Internet address.
+    ("sin_zero",   (ct.c_ubyte *  # # Pad to size of `struct sockaddr'.
+                     (ct.sizeof(sockaddr) -
+                      ct.sizeof(sa_family_t) -
+                      ct.sizeof(in_port_t) -
+                      ct.sizeof(in_addr)))),
+]
+
+# IPv6 AF_INET6 sockets:
+
+class in6_addr(ct.Union):
+    _fields_ = [
+    ("s6_addr",   (ct.c_uint8 * 16)),
+    ("s6_addr16", (ct.c_uint16 * 8)),
+    ("s6_addr32", (ct.c_uint32 * 4)),
+]
+
+class sockaddr_in6(ct.Structure):
+    _fields_ = [
+    ("sin6_family",   sa_family_t),  # address family, AF_INET6
+    ("sin6_port",     in_port_t),    # Transport layer port #
+    ("sin6_flowinfo", ct.c_uint32),  # IPv6 flow information
+    ("sin6_addr",     in6_addr),     # IPv6 address
+    ("sin6_scope_id", ct.c_uint32),  # IPv6 scope-id
 ]


### PR DESCRIPTION
Added some logic to load libpcap on Mac. I only have a x64 system so I left the exception for 32bit versions. I installed libpcap through homebrew. After the fixes I was able to:

```
$ python3
Python 3.9.9 (main, Dec  8 2021, 04:23:48)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import libpcap
>>> errbuf = bytes(libpcap.PCAP_BUF_SIZE)
>>> libpcap.config(LIBPCAP='/usr/local/opt/libpcap/lib/libpcap.dylib')
>>> libpcap.init(libpcap.PCAP_CHAR_ENC_UTF_8, errbuf)
0
>>>
```